### PR TITLE
Use sigmoid-threshold semantics for sparse-root splits; centralize split logic and add contract test

### DIFF
--- a/models/sparse_root.py
+++ b/models/sparse_root.py
@@ -15,7 +15,8 @@ Architecture
    features ready for the next level.
 
    Training: all nodes at every level are always expanded (teacher forcing).
-   Inference: only expand nodes where ``split_logit > 0`` (see inference note).
+   Inference: expand nodes by applying a sigmoid to ``split_logit`` and
+   comparing against the runtime split threshold (commonly 0.43).
 
 Output keys are **integers** (4, 3, 2, 1, 0) matching
 ``build_sparse_octree_targets``.

--- a/src/main/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunner.java
+++ b/src/main/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunner.java
@@ -68,6 +68,10 @@ public final class SparseRootModelRunner implements AutoCloseable {
     private static final String STEM = "sparse_root";
     /** Config sidecar filename. */
     private static final String CONFIG = "sparse_root_config.json";
+    /** Runtime config key for split expansion probability threshold. */
+    static final String SPLIT_THRESHOLD_CONFIG_KEY = "sparseRootSplitThreshold";
+    /** Default split expansion threshold used when runtime config does not override it. */
+    static final float DEFAULT_SPLIT_THRESHOLD = 0.43f;
 
     /** Octree depth. L4 = root, L0 = leaf (individual blocks). */
     private static final int LEVELS = 5;
@@ -79,7 +83,7 @@ public final class SparseRootModelRunner implements AutoCloseable {
     /**
      * Split threshold: sigmoid(split_logit) &gt; this → expand to children.
      * Set once at load time from runtime config key {@code "sparseRootSplitThreshold"}
-     * (default 0.6).  The same value is written to {@code sparse_root_config.json}
+     * (default 0.43). The same value is written to {@code sparse_root_config.json}
      * by {@code export_sparse_root.py} so training and runtime stay in sync.
      */
     private final float splitThreshold;
@@ -184,7 +188,7 @@ public final class SparseRootModelRunner implements AutoCloseable {
                     LOGGER.warn("[SparseRoot] {} not found — using raw block indices (no vocab)", configPath);
                 }
                 float splitThreshold = (float) com.rhythmatician.lodiffusion.Config
-                        .getDouble("sparseRootSplitThreshold", 0.6);
+                        .getDouble(SPLIT_THRESHOLD_CONFIG_KEY, DEFAULT_SPLIT_THRESHOLD);
                 LOGGER.debug("[SparseRoot] splitThreshold={}", splitThreshold);
                 return new SparseRootModelRunner(manager, zm, vocab, numClassesFromConfig,
                         splitThreshold, hasNoise2d, noise2dShape);
@@ -323,7 +327,7 @@ public final class SparseRootModelRunner implements AutoCloseable {
      * <p>Performs greedy top-down traversal:
      * <ol>
      *   <li>Start at the single L4 root node.</li>
-     *   <li>At each node, check {@code sigmoid(split_logit) > splitThreshold}.</li>
+     *   <li>At each node, evaluate {@link #shouldExpandNode(float, float)}.</li>
      *   <li>If <em>split</em>: enqueue all 8 children at the next finer level.</li>
      *   <li>If <em>leaf</em>: fill the node's sub-region with
      *       {@code argmax(label_logits)}.</li>
@@ -370,11 +374,11 @@ public final class SparseRootModelRunner implements AutoCloseable {
             // Root split
             if (splitByLevel[0] != null && splitByLevel[0].length > 0) {
                 float rootLogit = splitByLevel[0][0];
-                float rootSigm = 1.0f / (1.0f + (float) Math.exp(-rootLogit));
+                float rootSigm = sigmoid(rootLogit);
                 sb.append("\n  Root split logit=").append(rootLogit)
                   .append(" sigmoid=").append(String.format("%.4f", rootSigm))
                   .append(" threshold=").append(splitThreshold)
-                  .append(" => ").append(rootSigm > splitThreshold ? "SPLIT" : "LEAF");
+                  .append(" => ").append(shouldExpandNode(rootLogit, splitThreshold) ? "SPLIT" : "LEAF");
             }
             // Root label argmax
             if (labelByLevel[0] != null && cByLevel[0] > 0) {
@@ -432,9 +436,7 @@ public final class SparseRootModelRunner implements AutoCloseable {
             boolean isSplit = false;
             float[] splitArr = splitByLevel[lvlIdx];
             if (splitArr != null && lvlIdx < LEVELS - 1) {
-                float logit = splitArr[nodeIdx];
-                float sigm = 1.0f / (1.0f + (float) Math.exp(-logit));
-                isSplit = sigm > thresh;
+                isSplit = shouldExpandNode(splitArr[nodeIdx], thresh);
             }
 
             if (isSplit && lvlIdx < LEVELS - 1) {
@@ -521,6 +523,19 @@ public final class SparseRootModelRunner implements AutoCloseable {
             if (LEVEL_NODES[i] == n) return i;
         }
         return -1;
+    }
+
+
+    static boolean shouldExpandNode(float splitLogit, float splitThreshold) {
+        return sigmoid(splitLogit) > splitThreshold;
+    }
+
+    static float sigmoid(float value) {
+        return 1.0f / (1.0f + (float) Math.exp(-value));
+    }
+
+    static float logitForThreshold(float threshold) {
+        return (float) Math.log(threshold / (1.0f - threshold));
     }
 
     // ------------------------------------------------------------------

--- a/src/main/resources/lodiffusion.defaults.json
+++ b/src/main/resources/lodiffusion.defaults.json
@@ -6,6 +6,8 @@
   "threshold": 0.5,
   "inferenceDevice": "auto",
   "sparseRootSplitThreshold": 0.43,
+  "_commentSparseRootSplitThresholdRationale": "0.43 keeps borderline split logits active, preserving fine detail while still pruning many branches for faster decode.",
+  "_commentSparseRootSplitThresholdTradeoff": "Raise toward 0.5+ for sparser octrees and speed; lower toward 0.35 for denser octrees with more structural detail.",
   "datasetExportEnabled": false,
   "datasetExportPath": "dataset/",
   "datasetExportFormat": "BINARY"

--- a/src/test/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunnerContractTest.java
+++ b/src/test/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunnerContractTest.java
@@ -1,0 +1,29 @@
+package com.rhythmatician.lodiffusion.onnx;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for sparse-root split expansion semantics.
+ */
+class SparseRootModelRunnerContractTest {
+
+    @Test
+    void splitExpansion_boundaryRespectsStrictGreaterThanThreshold() {
+        float threshold = (float) com.rhythmatician.lodiffusion.Config.getDouble(
+                SparseRootModelRunner.SPLIT_THRESHOLD_CONFIG_KEY,
+                SparseRootModelRunner.DEFAULT_SPLIT_THRESHOLD);
+        assertTrue(threshold > 0.0f && threshold < 1.0f,
+                "sparseRootSplitThreshold must be in (0,1)");
+
+        float boundaryLogit = SparseRootModelRunner.logitForThreshold(threshold);
+
+        assertFalse(SparseRootModelRunner.shouldExpandNode(boundaryLogit, threshold),
+                "Node should not expand when sigmoid(logit) equals threshold exactly");
+        assertFalse(SparseRootModelRunner.shouldExpandNode(boundaryLogit - 0.01f, threshold),
+                "Node should not expand below threshold");
+        assertTrue(SparseRootModelRunner.shouldExpandNode(boundaryLogit + 0.01f, threshold),
+                "Node should expand above threshold");
+    }
+}


### PR DESCRIPTION
### Motivation

- Clarify and standardise the runtime split decision so inference uses thresholded sigmoid semantics instead of ambiguous hardcoded `split_logit > 0` wording. 
- Keep a single canonical split-decision implementation in the Java runtime and document the chosen default threshold and its tradeoffs.

### Description

- Update `models/sparse_root.py` docstring to describe inference as applying `sigmoid(split_logit)` and comparing to a runtime split threshold rather than stating `split_logit > 0`.
- Centralise split/threshold logic in `src/main/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunner.java` by adding `SPLIT_THRESHOLD_CONFIG_KEY`, `DEFAULT_SPLIT_THRESHOLD = 0.43f`, a `shouldExpandNode(float, float)` helper, a `sigmoid` helper, and `logitForThreshold`, and replace inline sigmoid checks with calls to the new helper.
- Document rationale and expected sparsity tradeoffs by adding explanatory comment fields to `src/main/resources/lodiffusion.defaults.json` near `sparseRootSplitThreshold`.
- Add `src/test/java/com/rhythmatician/lodiffusion/onnx/SparseRootModelRunnerContractTest.java` which verifies strict-`>` semantics at the configured boundary logit using `logitForThreshold` and `shouldExpandNode`.

### Testing

- Applied the code changes and attempted to run targeted tests with `./gradlew test --tests com.rhythmatician.lodiffusion.onnx.SparseRootModelRunnerContractTest --tests com.rhythmatician.lodiffusion.onnx.SparseRootModelRunnerSmokeTest` but the build failed due to the environment reporting `Unsupported class file major version 69` (Java/Gradle toolchain mismatch), so the JVM-based tests could not be executed in CI here.
- Static validation and quick repository scans were performed to ensure references to the split threshold and helper functions were updated consistently and the new test file was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8473caed483299afe749e163f834f)