### PR TITLE
Separate GPU readbacks from production dispatch; add staging contract and readback metrics

### DIFF
--- a/src/main/java/io/github/lodiffusion/worldgen/ShaderSSBOManager.java
+++ b/src/main/java/io/github/lodiffusion/worldgen/ShaderSSBOManager.java
@@ -6,6 +6,8 @@ import org.lwjgl.opengl.GL43C;
 
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages OpenGL Shader Storage Buffer Objects (SSBOs) for GPU terrain generation.
@@ -60,6 +62,32 @@ public class ShaderSSBOManager {
     private int[] bufferIds = new int[BUFFER_COUNT];
     private boolean initialized = false;
     private long lastUploadTime = 0L;
+    private int lastDispatchedChunkX = 0;
+    private int lastDispatchedChunkZ = 0;
+
+    /** Readback telemetry counters (debug/parity path only). */
+    private long readbackWindowStartMs = System.currentTimeMillis();
+    private long readbackWindowCalls = 0;
+    private double readbackCallsPerSec = 0.0d;
+    private final Map<Long, Long> readbackBytesByChunk = new HashMap<>();
+
+    /**
+     * Production contract between compute output buffers and model-input staging.
+     *
+     * <p>This object intentionally contains GPU buffer handles only (no CPU copies),
+     * so call sites can wire GPU-resident pipelines and materialize to CPU only when
+     * explicitly requested by debug tooling.
+     */
+    public record ChunkGpuOutputs(
+            int chunkX,
+            int chunkZ,
+            int densityBinding,
+            int densityBufferId,
+            int densityFloatCount,
+            int blockBinding,
+            int blockBufferId,
+            int blockIntCount
+    ) {}
 
     public ShaderSSBOManager() {
         // Buffers will be created on-demand during first upload
@@ -179,7 +207,27 @@ public class ShaderSSBOManager {
      */
     public void dispatch(int chunkX, int chunkZ) {
         if (!initialized || !shaderManager.isCompiled() || !dispatcher.isReady()) return;
+        lastDispatchedChunkX = chunkX;
+        lastDispatchedChunkZ = chunkZ;
         dispatcher.dispatch(chunkX, chunkZ);
+    }
+
+    /**
+     * Production dispatch path: executes terrain compute and returns GPU buffer handles
+     * for downstream staging without any CPU readback.
+     */
+    public ChunkGpuOutputs dispatchForStaging(int chunkX, int chunkZ) {
+        dispatch(chunkX, chunkZ);
+        return new ChunkGpuOutputs(
+                chunkX,
+                chunkZ,
+                DENSITY_OUTPUT_BINDING,
+                bufferIds[DENSITY_OUTPUT_BINDING],
+                DENSITY_FLOATS,
+                BLOCK_OUTPUT_BINDING,
+                bufferIds[BLOCK_OUTPUT_BINDING],
+                BLOCK_INT_COUNT
+        );
     }
 
     /**
@@ -341,9 +389,9 @@ public class ShaderSSBOManager {
      * @return FloatBuffer of {@value #DENSITY_FLOATS} floats, indexed
      *         {@code [lx + 16*lz] * 384 + (by + 64)}, or {@code null} on failure.
      */
-    public FloatBuffer dispatchAndRead(int chunkX, int chunkZ) {
+    public FloatBuffer dispatchAndReadDebug(int chunkX, int chunkZ) {
         dispatch(chunkX, chunkZ);
-        return readBuffer(DENSITY_OUTPUT_BINDING, DENSITY_FLOATS);
+        return readDensityDebug();
     }
 
     /** Number of floats in one dispatched chunk density field ({@value}). */
@@ -362,8 +410,13 @@ public class ShaderSSBOManager {
      * @return IntBuffer of {@value #BLOCK_INT_COUNT} ints (positioned at 0), or
      *         {@code null} on error.
      */
-    public IntBuffer readBlockOutput() {
-        return readIntBuffer(BLOCK_OUTPUT_BINDING, BLOCK_INT_COUNT);
+    public IntBuffer readBlockOutputDebug() {
+        return readIntBufferDebug(BLOCK_OUTPUT_BINDING, BLOCK_INT_COUNT);
+    }
+
+    /** Read density output from binding 7 for parity/debug use only. */
+    public FloatBuffer readDensityDebug() {
+        return readBufferDebug(DENSITY_OUTPUT_BINDING, DENSITY_FLOATS);
     }
 
     /**
@@ -373,7 +426,7 @@ public class ShaderSSBOManager {
      * @param elementCount number of ints to read
      * @return IntBuffer positioned at 0, or {@code null} on error
      */
-    public IntBuffer readIntBuffer(int bindingPoint, int elementCount) {
+    public IntBuffer readIntBufferDebug(int bindingPoint, int elementCount) {
         if (bindingPoint < 0 || bindingPoint >= BUFFER_COUNT || bufferIds[bindingPoint] == 0) {
             return null;
         }
@@ -382,6 +435,7 @@ public class ShaderSSBOManager {
             org.lwjgl.opengl.GL43C.glBindBuffer(GL_SHADER_STORAGE_BUFFER, bufferIds[bindingPoint]);
             org.lwjgl.opengl.GL43C.glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, result);
             result.rewind();
+            recordReadback((long) elementCount * Integer.BYTES);
             return result;
         } catch (Exception e) {
             LOGGER.error("ShaderSSBOManager: Failed to read int buffer from binding {}", bindingPoint, e);
@@ -397,7 +451,7 @@ public class ShaderSSBOManager {
      * @param elementCount Number of floats to read
      * @return A FloatBuffer containing the GPU-side data
      */
-    public FloatBuffer readBuffer(int bindingPoint, int elementCount) {
+    public FloatBuffer readBufferDebug(int bindingPoint, int elementCount) {
         if (bindingPoint < 0 || bindingPoint >= BUFFER_COUNT || bufferIds[bindingPoint] == 0) {
             return null;
         }
@@ -407,6 +461,7 @@ public class ShaderSSBOManager {
             glBindBuffer(GL_SHADER_STORAGE_BUFFER, bufferIds[bindingPoint]);
             GL43C.glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, result);
             result.rewind();
+            recordReadback((long) elementCount * Float.BYTES);
             return result;
         } catch (Exception e) {
             LOGGER.error("ShaderSSBOManager: Failed to read buffer from binding {}", bindingPoint, e);
@@ -470,6 +525,28 @@ public class ShaderSSBOManager {
             return 0;
         }
         return bufferIds[bindingPoint];
+    }
+
+    private void recordReadback(long bytes) {
+        long now = System.currentTimeMillis();
+        readbackWindowCalls++;
+        long elapsed = now - readbackWindowStartMs;
+        if (elapsed >= 1000) {
+            readbackCallsPerSec = (readbackWindowCalls * 1000.0d) / Math.max(1L, elapsed);
+            readbackWindowCalls = 0;
+            readbackWindowStartMs = now;
+        }
+
+        long chunkKey = (((long) lastDispatchedChunkX) << 32) | (lastDispatchedChunkZ & 0xffffffffL);
+        long chunkBytes = readbackBytesByChunk.merge(chunkKey, bytes, Long::sum);
+
+        LOGGER.info(
+                "ShaderSSBOManager metrics: readback_bytes_chunk[{},{}]={} readback_calls_sec={}",
+                lastDispatchedChunkX,
+                lastDispatchedChunkZ,
+                chunkBytes,
+                String.format("%.2f", readbackCallsPerSec)
+        );
     }
 
     // ============================================================================

--- a/src/main/java/io/github/lodiffusion/worldgen/TerrainComputeDispatcher.java
+++ b/src/main/java/io/github/lodiffusion/worldgen/TerrainComputeDispatcher.java
@@ -33,7 +33,8 @@ import java.nio.ByteOrder;
  *   d.init(shaderProgramManager, RouterConfig.overworldDefaults(data));
  *   // per chunk:
  *   d.dispatch(chunkX, chunkZ);
- *   FloatBuffer result = ssboManager.readBuffer(7, 16 * 384 * 16);
+ *   // optional debug/parity only:
+ *   FloatBuffer result = ssboManager.readDensityDebug();
  *   // on world unload:
  *   d.cleanup();
  * </pre>

--- a/src/main/java/io/github/lodiffusion/worldgen/WorldGenEventHandler.java
+++ b/src/main/java/io/github/lodiffusion/worldgen/WorldGenEventHandler.java
@@ -36,6 +36,17 @@ public class WorldGenEventHandler {
     /** Current singleton instance (one per server lifecycle) */
     private static WorldGenEventHandler instance;
 
+    /**
+     * Debug readback toggles (all disabled by default for production runtime).
+     *
+     * <p>-Dlodiffusion.worldgen.debugDensityReadback=true  -> reads full density buffer
+     * <p>-Dlodiffusion.worldgen.debugBlockReadback=true    -> reads full block-material buffer
+     * <p>-Dlodiffusion.worldgen.writeParityReport=true     -> writes parity JSON (implies density readback)
+     */
+    private static final boolean DEBUG_DENSITY_READBACK = Boolean.getBoolean("lodiffusion.worldgen.debugDensityReadback");
+    private static final boolean DEBUG_BLOCK_READBACK = Boolean.getBoolean("lodiffusion.worldgen.debugBlockReadback");
+    private static final boolean WRITE_PARITY_REPORT = Boolean.getBoolean("lodiffusion.worldgen.writeParityReport");
+
     // Cached reflection metadata for Minecraft classes (loaded lazily)
     private final Class<?> serverLevelClass;
     private final Class<?> minecraftServerClass;
@@ -211,27 +222,35 @@ public class WorldGenEventHandler {
 
             activeLevels.put(level, manager);
 
-            // Dispatch GPU compute for chunk (0,0) as a cold-start validation pass
-            LOGGER.info("Dispatching GPU compute for validation (chunk 0,0)...");
-            FloatBuffer allDensity = manager.dispatchAndRead(0, 0);
-            LOGGER.info("Compute dispatch complete — validating Binding 7 output...");
+            // Production path: dispatch and hand off GPU buffer handles for staging.
+            LOGGER.info("Dispatching GPU compute for startup chunk (0,0) without CPU readback...");
+            ShaderSSBOManager.ChunkGpuOutputs outputs = manager.dispatchForStaging(0, 0);
+            stageGpuOutputs(outputs, dimensionInfo);
 
-            if (allDensity != null && allDensity.hasRemaining()) {
-                // Log first 10 samples for quick liveness check
-                StringBuilder log = new StringBuilder("GPU Density Samples [0-9]: ");
-                for (int i = 0; i < 10 && allDensity.hasRemaining(); i++) {
-                    log.append(String.format("%.4f", allDensity.get())).append(" ");
+            // Optional debug/parity validation path (explicitly gated).
+            if (DEBUG_DENSITY_READBACK || WRITE_PARITY_REPORT) {
+                FloatBuffer allDensity = manager.readDensityDebug();
+                if (allDensity != null && allDensity.hasRemaining()) {
+                    StringBuilder log = new StringBuilder("GPU Density Samples [0-9]: ");
+                    for (int i = 0; i < 10 && allDensity.hasRemaining(); i++) {
+                        log.append(String.format("%.4f", allDensity.get())).append(" ");
+                    }
+                    LOGGER.info(log.toString());
+
+                    if (WRITE_PARITY_REPORT) {
+                        writeGpuParityFile(allDensity, dimensionInfo);
+                    }
+                } else {
+                    LOGGER.warn("Unable to read density output from GPU (null or empty buffer)");
                 }
-                LOGGER.info(log.toString());
-
-                // Write full density output for WS-1.3 parity validation
-                writeGpuParityFile(allDensity, dimensionInfo);
-            } else {
-                LOGGER.warn("Unable to read density output from GPU (null or empty buffer)");
             }
 
-            // WS-2: Read block-material output and push to Voxy
-            writeBlocksToVoxy(manager, level, dimensionInfo);
+            // WS-2 debug path: only read block materials when explicitly enabled.
+            if (DEBUG_BLOCK_READBACK) {
+                writeBlocksToVoxy(manager, level, dimensionInfo);
+            } else {
+                LOGGER.debug("WS-2: block readback disabled (set -Dlodiffusion.worldgen.debugBlockReadback=true to enable)");
+            }
 
             long elapsedMs = System.currentTimeMillis() - startTime;
             LOGGER.info("WorldGenEventHandler.onWorldLoad complete in {} ms", elapsedMs);
@@ -258,7 +277,7 @@ public class WorldGenEventHandler {
             return;
         }
         try {
-            IntBuffer blockMat = manager.readBlockOutput();
+            IntBuffer blockMat = manager.readBlockOutputDebug();
             if (blockMat == null) {
                 LOGGER.warn("WS-2: block output buffer is null — skipping Voxy write");
                 return;
@@ -346,6 +365,29 @@ public class WorldGenEventHandler {
         } catch (Exception e) {
             LOGGER.warn("WS-1.3 parity: failed to write GPU density file", e);
         }
+    }
+
+
+    /**
+     * Production dataflow boundary: pass GPU-resident chunk outputs to downstream staging.
+     *
+     * <p>This method intentionally does not materialize density/block payloads on CPU.
+     * It defines the contract needed for model input staging (or a direct GPU-resident
+     * ingest path) to consume compute outputs by buffer ID + metadata.
+     */
+    private void stageGpuOutputs(ShaderSSBOManager.ChunkGpuOutputs outputs, String dimensionInfo) {
+        LOGGER.debug(
+                "GPU staging contract ready for {} chunk ({}, {}): density[binding={}, id={}, floats={}], block[binding={}, id={}, ints={}]",
+                dimensionInfo,
+                outputs.chunkX(),
+                outputs.chunkZ(),
+                outputs.densityBinding(),
+                outputs.densityBufferId(),
+                outputs.densityFloatCount(),
+                outputs.blockBinding(),
+                outputs.blockBufferId(),
+                outputs.blockIntCount()
+        );
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Avoid per-chunk CPU readbacks during normal world generation by separating debug/parity readback paths from the production GPU-resident dataflow. 
- Define a minimal production contract so downstream systems can consume GPU outputs by handle/metadata instead of forcing `glGetBufferSubData` and CPU materialization.

### Description
- Split `ShaderSSBOManager` APIs into production staging and debug-only readbacks by adding `dispatchForStaging(...)` and the `ChunkGpuOutputs` record while renaming/introducing debug-read methods (`dispatchAndReadDebug`, `readDensityDebug`, `readBlockOutputDebug`, `readBufferDebug`, `readIntBufferDebug`) so normal dispatch does not call `glGetBufferSubData` per chunk. 
- Implement a GPU-only production contract carrying buffer binding/ID/count metadata in `ChunkGpuOutputs` to allow model-input staging or GPU-resident ingestion without CPU copies. 
- Update `WorldGenEventHandler` startup/dispatcher flow to default to GPU staging and add JVM flags to gate debug behavior: `-Dlodiffusion.worldgen.debugDensityReadback`, `-Dlodiffusion.worldgen.debugBlockReadback`, and `-Dlodiffusion.worldgen.writeParityReport`, and add `stageGpuOutputs(...)` as the staging boundary. 
- Add readback telemetry in `ShaderSSBOManager` (`recordReadback`) that logs cumulative readback bytes per chunk and a rolling `readback_calls_sec` metric, and document the dispatcher as debug-only for CPU materialization; also update `TerrainComputeDispatcher` docs to reflect debug-only reading. 

### Testing
- Ran `./gradlew compileJava -q` to validate Java build; the build attempt failed in this environment due to Gradle/JDK compatibility with error `Unsupported class file major version 69`, not due to compilation errors introduced by these changes. 
- Performed local static verification of modified call sites and grep checks to ensure production paths use `dispatchForStaging` and readbacks are only invoked from debug-gated branches; no unit tests were executed due to the environment JVM/Gradle mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84745752c8329a5cf14fd75039a7e)